### PR TITLE
username wip

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,6 @@ class ApplicationController < ActionController::Base
 protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,9 +9,9 @@ class EventsController < ApplicationController
   # GET /events
   # GET /events.json
   def index
-    @future_events = Event.in_the_future.with_attached_image.
+    @future_events = current_user.relevant_events.in_the_future.with_attached_image.
     includes([:address, user: [avatar_attachment: :blob]])
-    @past_events = Event.from_the_past.page(params[:page]).per(5).
+    @past_events = current_user.relevant_events.from_the_past.page(params[:page]).per(5).
     with_attached_image.includes([:address, user: [avatar_attachment: :blob]])
   end
 
@@ -79,13 +79,13 @@ class EventsController < ApplicationController
   end
 
   def calendar
-    @events = Event.future_and_past
+    @events = current_user.relevant_events.future_and_past
   end
 
 private
   # Use callbacks to share common setup or constraints between actions.
   def set_event
-    @event = Event.includes([comments: :created_by, users: :avatar_attachment]).find_by(id: params[:id])
+    @event = current_user.relevant_events.includes([comments: :created_by, users: :avatar_attachment]).find_by(id: params[:id])
     redirect_to events_path unless @event
   end
 

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -44,6 +44,6 @@ private
 
   def receive_mail_params
     params.require(:receive_mail).permit(:for_new_posts,
-      :for_new_events, :for_new_comments)
+      :for_new_events, :for_new_comments, :for_new_relationships)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -100,12 +100,11 @@ private
   end
 
   def user_params
-    params.require(:user).permit(:username, :first_name, :last_name, :avatar, :timezone,
+    params.require(:user).permit(
+      :username, :first_name, :last_name, :avatar, :timezone,
       profile_attributes: [:id, :bio, :workplace, :position, :birthday,
       :graduated_in, :show_email, :user_id, :_destroy],
-      phones_attributes: [:id, :number, :device, :extension, :_destroy],
-      addresses_attributes: [:id, :street_1, :street_2, :city, :state, :zip,
-      :location, :_destroy],
-      websites_attributes: [:id, :name, :address, :_destroy])
+      websites_attributes: [:id, :name, :address, :_destroy]
+    )
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,10 +11,10 @@ class UsersController < ApplicationController
   def index
     @users =
       if params[:search]
-        User.by_first_name.search_by(params[:search]).
+        User.by_username.search_by(params[:search]).
         with_attached_avatar.includes(:profile)
       else
-        User.by_first_name.with_attached_avatar.includes(:profile)
+        User.by_username.with_attached_avatar.includes(:profile)
       end
     @show_occupation = true
   end
@@ -59,16 +59,16 @@ class UsersController < ApplicationController
 
   def search
     @users = User.search_by(params[:term])
-    render json: @users.map(&:full_name)
+    render json: @users.search_results
   end
 
   def admins
     @users =
       if params[:search]
-        User.by_first_name.search_by(params[:search]).
+        User.by_username.search_by(params[:search]).
         with_attached_avatar.includes(:profile)
       else
-        User.by_first_name.with_attached_avatar.includes(:profile)
+        User.by_username.with_attached_avatar.includes(:profile)
       end
   end
 
@@ -100,7 +100,7 @@ private
   end
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :avatar, :timezone,
+    params.require(:user).permit(:username, :first_name, :last_name, :avatar, :timezone,
       profile_attributes: [:id, :bio, :workplace, :position, :birthday,
       :graduated_in, :show_email, :user_id, :_destroy],
       phones_attributes: [:id, :number, :device, :extension, :_destroy],

--- a/app/mailers/new_activity_mailer.rb
+++ b/app/mailers/new_activity_mailer.rb
@@ -15,6 +15,6 @@ class NewActivityMailer < ApplicationMailer
     attachments.inline['bullhorn.png'] = File.read("#{Rails.root}/app/assets/images/bullhorn.png")
 
     mail to: @to_user.email,
-    subject: "New Activity - #{@from_user.full_name} has made a New #{@notifiable.class.name}"
+    subject: "New Activity - #{@from_user.username} has made a New #{@notifiable.class.name}"
   end
 end

--- a/app/mailers/new_activity_mailer.rb
+++ b/app/mailers/new_activity_mailer.rb
@@ -7,14 +7,15 @@ class NewActivityMailer < ApplicationMailer
   #
   #   en.new_activity_mailer.new_post.subject
   #
-  def new_activity(to, from, notifiable)
+  def new_activity(to, from, notifiable, action_statement)
     @to_user = to
     @from_user = from
     @notifiable = notifiable
+    @action_statement = action_statement
 
     attachments.inline['bullhorn.png'] = File.read("#{Rails.root}/app/assets/images/bullhorn.png")
 
     mail to: @to_user.email,
-    subject: "New Activity - #{@from_user.username} has made a New #{@notifiable.class.name}"
+    subject: "New Activity - #{@from_user.username} has #{@action_statement}"
   end
 end

--- a/app/models/concerns/create_notifications.rb
+++ b/app/models/concerns/create_notifications.rb
@@ -32,7 +32,8 @@ private
       NewActivityMailer.new_activity(
         recipient,
         notifier,
-        notifiable
+        notifiable,
+        action_statement(notifiable)
       ).deliver_now
     end
   end
@@ -79,18 +80,18 @@ private
   def action_statement(notifiable)
     case notifiable.class.name
     when 'Post'
-      'added a new post'
+      'Added a New Post'
     when 'Event'
-      'created a new event'
+      'Created a New Event'
     when 'Relationship'
-      'started following you'
+      'Started Following You'
     when 'Comment'
       commentable_class_name = notifiable.commentable.class.name.downcase
-      "commented on
+      "Commented on
       #{an_or_a(commentable_class_name)}
       #{commentable_class_name}"
     else
-      'posted something new'
+      'Posted Something New'
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,11 @@ class User < ApplicationRecord
   # scope :by_accepts_email, -> { where(receive_email: true) }
   scope :all_but_current, -> (current_user) { where.not(id: current_user) }
 
+  def relevant_events
+    user_ids = following_ids << id
+    Event.where(user: user_ids)
+  end
+  
   def full_name
     if first_name.present? || last_name.present?
       [first_name, last_name].join(' ')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,28 +40,42 @@ class User < ApplicationRecord
 
   has_one_attached :avatar
 
-  validates :first_name, presence: true
-  validates :last_name, presence: true
+  validates :username, presence: true, uniqueness: { case_sensitive: false }
   validates :avatar, file_content_type: {
     allow: ['image/jpg', 'image/jpeg', 'image/gif', 'image/png']
   }, if: -> { avatar.attached? }
 
-  scope :search_by, -> (term) {
-    where("first_name ILIKE :search
+  def self.search_by(term)
+    where(
+      "first_name ILIKE :search
       OR last_name ILIKE :search
+      OR username ILIKE :search
       OR first_name || \' \' || last_name ILIKE :search
-      OR last_name || \' \' || first_name ILIKE :search",
-      search: "%#{term}%")
-    }
+      OR last_name || \' \' || first_name ILIKE :search
+      OR username || \' \' || first_name || \' \' || last_name ILIKE :search
+      OR username || \' - \' || first_name || \' \' || last_name ILIKE :search",
+      search: "%#{term}%"
+    )
+  end
 
-  scope :by_first_name, -> { order(first_name: :asc) }
+  def self.search_results
+    all.map do |user|
+      [user.username, user.full_name].compact.join(" - ")
+    end
+  end
+
+  scope :by_username, -> { order(username: :asc) }
   scope :by_admin, -> { where(is_admin: true) }
   scope :by_other_user, -> { where(is_admin: false) }
   # scope :by_accepts_email, -> { where(receive_email: true) }
   scope :all_but_current, -> (current_user) { where.not(id: current_user) }
 
   def full_name
-    [first_name, last_name].join(' ')
+    if first_name.present? || last_name.present?
+      [first_name, last_name].join(' ')
+    else
+      nil
+    end
   end
 
   def following?(user)

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -7,12 +7,8 @@
     data: { turbo: false } do |f|
       = render 'notifications/error_messages', object: f.object
       .field.mb-3
-        = f.label :first_name, class: "form-label"
-        = f.text_field :first_name, autofocus: true, autocomplete: "first name",
-        class: "form-control"
-      .field.mb-3
-        = f.label :last_name, class: "form-label"
-        = f.text_field :last_name, autocomplete: "last name",
+        = f.label :username, class: "form-label"
+        = f.text_field :username, autofocus: true, autocomplete: "first name",
         class: "form-control"
       .field.mb-3
         = f.label :email, class: "form-label"

--- a/app/views/layouts/_sub_top_bar.html.haml
+++ b/app/views/layouts/_sub_top_bar.html.haml
@@ -3,8 +3,8 @@
     .container-fluid
       %ul.navbar-nav
         %li.nav-item
-          = link_to users_path, title: 'Roster', class: "nav-link" do
-            = fa_icon 'users', text: 'Roster'
+          = link_to users_path, title: 'Explore Users', class: "nav-link" do
+            = fa_icon 'users', text: 'Explore Users'
         %li.nav-item
           = link_to events_path, title: 'Events', class: "nav-link" do
             = fa_icon 'calendar', text: 'Events', type: :regular

--- a/app/views/layouts/_sub_top_bar.html.haml
+++ b/app/views/layouts/_sub_top_bar.html.haml
@@ -8,8 +8,8 @@
         %li.nav-item
           = link_to events_path, title: 'Events', class: "nav-link" do
             = fa_icon 'calendar', text: 'Events', type: :regular
-            - if Event.in_the_future.any?
-              %span.count= Event.in_the_future.count
+            - if current_user.relevant_events.in_the_future.any?
+              %span.count= current_user.relevant_events.in_the_future.count
         %li.nav-item
           = link_to notifications_path, title: 'Notifications', class: "nav-link" do
             = fa_icon 'bell'

--- a/app/views/new_activity_mailer/new_activity.html.haml
+++ b/app/views/new_activity_mailer/new_activity.html.haml
@@ -1,10 +1,10 @@
 %h1
-  New #{@notifiable.class.name} - #{@from_user.username}
+  #{@action_statement} - #{@from_user.username}
 %p
   Dear #{@to_user.first_name},
 %p
   Just thought you might like to know,
-  #{@from_user.username} has made a New #{@notifiable.class.name}.
+  #{@from_user.username} has #{@action_statement}.
 %p
   = link_to 'Go check it out', path_to_notifiable(@notifiable)
 %p

--- a/app/views/new_activity_mailer/new_activity.html.haml
+++ b/app/views/new_activity_mailer/new_activity.html.haml
@@ -1,10 +1,10 @@
 %h1
-  New #{@notifiable.class.name} - #{@from_user.full_name}
+  New #{@notifiable.class.name} - #{@from_user.username}
 %p
   Dear #{@to_user.first_name},
 %p
   Just thought you might like to know,
-  #{@from_user.full_name} has made a New #{@notifiable.class.name}.
+  #{@from_user.username} has made a New #{@notifiable.class.name}.
 %p
   = link_to 'Go check it out', path_to_notifiable(@notifiable)
 %p

--- a/app/views/new_activity_mailer/new_activity.text.haml
+++ b/app/views/new_activity_mailer/new_activity.text.haml
@@ -3,6 +3,6 @@ New Activity
 Dear #{@to_user.first_name},
 
 Just thought you might like to know,
-#{@from_user.full_name} has made a New #{@notifiable.class.name}.
+#{@from_user.username} has made a New #{@notifiable.class.name}.
 
 = link_to 'Go check it out', path_to_notifiable(@notifiable)

--- a/app/views/new_activity_mailer/new_activity.text.haml
+++ b/app/views/new_activity_mailer/new_activity.text.haml
@@ -3,6 +3,6 @@ New Activity
 Dear #{@to_user.first_name},
 
 Just thought you might like to know,
-#{@from_user.username} has made a New #{@notifiable.class.name}.
+#{@from_user.username} has #{@action_statement}.
 
 = link_to 'Go check it out', path_to_notifiable(@notifiable)

--- a/app/views/notifications/_notification.html.haml
+++ b/app/views/notifications/_notification.html.haml
@@ -2,7 +2,7 @@
   = link_to path_to_notifiable(notification.notifiable), class: "post_user" do
     - if notification.notifier.avatar.attached?
       = image_tag thumb_image(notification.notifier.avatar)
-    = notification.notifier.full_name
+    = notification.notifier.username
     = notification.action
     .timestamp
       #{time_ago_in_words(notification.created_at)} ago

--- a/app/views/notifications/edit.html.haml
+++ b/app/views/notifications/edit.html.haml
@@ -8,16 +8,19 @@
     data: { turbo: false } do |f|
       = render 'notifications/error_messages', object: f.object
 
-      .mb-3 Receive email notifications when users:
+      .mb-3 Receive email notifications when users you follow:
       .feild.mb-1
         = f.check_box :for_new_posts, id: 'cb_posts'
         = f.label :for_new_posts, 'create a new Post', for: 'cb_posts'
       .feild.mb-1
         = f.check_box :for_new_events, id: 'cb_events'
         = f.label :for_new_events, 'create a new Event', for: 'cb_events'
-      .feild.mb-3
+      .feild.mb-1
         = f.check_box :for_new_comments, id: 'cb_comments'
         = f.label :for_new_comments,
         'Comment on something you have posted or commented on', for: 'cb_comments'
+      .feild.mb-3
+        = f.check_box :for_new_relationships, id: 'cb_relationships'
+        = f.label :for_new_relationships, 'start following you', for: 'cb_relationships'
       .actions.mb-3
         = f.submit 'Update Notification settings', class: 'btn btn-primary'

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -9,5 +9,5 @@
       = link_to root_path(anchor: "post_#{@post.id}"), title: 'Back' do
         = fa_icon 'hand-point-left', text: 'Back'
       - if @post.images.attached?
-        = link_to photos_user_path(@post.user), title: "#{@post.user.full_name} Photos" do
-          = fa_icon 'image', text: "#{@post.user.full_name} Photos"
+        = link_to photos_user_path(@post.user), title: "#{@post.user.username} Photos" do
+          = fa_icon 'image', text: "#{@post.user.username} Photos"

--- a/app/views/users/_avatar_info.html.haml
+++ b/app/views/users/_avatar_info.html.haml
@@ -8,8 +8,4 @@
       %h3= user.username
   = render "users/profile_stats", user: user
   = render "relationships/form", user: user
-  - if user.profile.try(:graduated_in).present?
-    .class_of.mb-1
-      Class of
-      = user.profile.graduated_in.strftime('%Y')
   .occupation= user.profile.occupation if user.profile.try(:occupation) && @show_occupation

--- a/app/views/users/_avatar_info.html.haml
+++ b/app/views/users/_avatar_info.html.haml
@@ -5,7 +5,7 @@
 .avatar-info
   .name.mb-1
     = link_to user, class: "black_text_link" do
-      %h3= user.full_name
+      %h3= user.username
   = render "users/profile_stats", user: user
   = render "relationships/form", user: user
   - if user.profile.try(:graduated_in).present?

--- a/app/views/users/_follow_header.html.haml
+++ b/app/views/users/_follow_header.html.haml
@@ -2,6 +2,6 @@
   .col-12
     .callout-transparent
       .center-text
-        %h1.no-background= user.full_name
+        %h1.no-background= user.username
         = render 'users/profile_stats', user: user
         = render 'relationships/form', user: user

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -23,8 +23,6 @@
             = link_to 'Remove avatar', remove_avatar_user_path(f.object),
             class: "btn btn-danger btn-sm"
   = render 'profile/form', f: f
-  = render 'phones/phone_form', f: f
-  = render 'addresses/address_form', f: f
   = render 'websites/website_form', f: f
   .row
     .col-12

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -1,7 +1,10 @@
-= form_with model: user, local: true do |f|
+= form_with model: user, data: {turbo: false} do |f|
   = render 'notifications/error_messages', object: f.object
   .row
     .col-12.col-lg-6
+      .field.mb-3
+        = f.label :username, class: "form-label"
+        = f.text_field :username, class: "form-control"
       .field.mb-3
         = f.label :first_name, class: "form-label"
         = f.text_field :first_name, class: "form-control"

--- a/app/views/users/_post_user.html.haml
+++ b/app/views/users/_post_user.html.haml
@@ -4,4 +4,4 @@
       = image_tag thumb_image(user.avatar)
     - else
       = fa_icon 'user', class: 'no_avatar'
-    = user.full_name
+    = user.username

--- a/app/views/users/_profile_info.html.haml
+++ b/app/views/users/_profile_info.html.haml
@@ -7,6 +7,11 @@
     .info
       %b Bio:
       = simple_format(user.profile.bio)
+  - if user.profile.try(:graduated_in).present?
+    .info
+      %b 
+        Class of
+        = user.profile.graduated_in.strftime('%Y')
   - if user.profile.try(:workplace).present?
     .info
       %b Workplace:

--- a/app/views/users/_profile_info.html.haml
+++ b/app/views/users/_profile_info.html.haml
@@ -1,4 +1,8 @@
 .profile_info
+  - if user.try(:full_name).present?
+    .info
+      %b name:
+      = user.full_name
   - if user.profile.try(:bio).present?
     .info
       %b Bio:

--- a/app/views/users/_profile_info.html.haml
+++ b/app/views/users/_profile_info.html.haml
@@ -23,14 +23,6 @@
     .info
       %b Email:
       = user.email
-  - if user.phones.any?
-    .info
-      %b #{'Phone'.pluralize(user.phones.count)}:
-      = render user.phones
-  - if user.addresses.any?
-    .info
-      %b #{'Address'.pluralize(user.addresses.count)}:
-      = user.addresses.list
   - if user.websites.any?
     .info
       %b #{'Website'.pluralize(user.websites.count)}:

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -2,8 +2,8 @@
 = render 'users/search_box'
 .row
   .col-12
-    %h1 Members Roster
+    %h1 Explore Users
     %p
       = @users.count
-      members
+      users
     = render 'users/badge', users: @users

--- a/app/views/users/photos.html.haml
+++ b/app/views/users/photos.html.haml
@@ -1,7 +1,7 @@
 - provide :title, 'My Photos'
 .row
   .col-12
-    %h1= "#{@user.full_name}'s Photos"
+    %h1= "#{@user.username}'s Photos"
 .row
   - @user.posts.with_images.each do |post|
     .col-12.col-md-6.col-lg-3

--- a/db/migrate/20230211001704_add_username_to_users.rb
+++ b/db/migrate/20230211001704_add_username_to_users.rb
@@ -1,0 +1,13 @@
+class AddUsernameToUsers < ActiveRecord::Migration[7.0]
+  enable_extension 'citext'
+  def change
+    add_column :users, :username, :citext, unique: true
+
+    User.find_each.with_index do |user, index|
+      user.username = "username_#{index}"
+      user.save
+    end
+
+    change_column_null :users, :username, false
+  end
+end

--- a/db/migrate/20230212220106_change_show_email_to_false_profiles.rb
+++ b/db/migrate/20230212220106_change_show_email_to_false_profiles.rb
@@ -1,0 +1,5 @@
+class ChangeShowEmailToFalseProfiles < ActiveRecord::Migration[7.0]
+  def change
+    change_column :profiles, :show_email, :boolean, default: false
+  end
+end

--- a/db/migrate/20230212220734_add_for_new_followers_to_receive_mails.rb
+++ b/db/migrate/20230212220734_add_for_new_followers_to_receive_mails.rb
@@ -1,0 +1,5 @@
+class AddForNewFollowersToReceiveMails < ActiveRecord::Migration[7.0]
+  def change
+    add_column :receive_mails, :for_new_relationships, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_11_001704) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_12_220734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -132,7 +132,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_11_001704) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.boolean "show_email", default: true
+    t.boolean "show_email", default: false
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 
@@ -143,6 +143,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_11_001704) do
     t.boolean "for_new_comments", default: true
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.boolean "for_new_relationships", default: true
     t.index ["user_id"], name: "index_receive_mails_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_29_220109) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_11_001704) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -175,6 +176,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_29_220109) do
     t.string "confirmation_token"
     t.datetime "confirmed_at", precision: nil
     t.datetime "confirmation_sent_at", precision: nil
+    t.citext "username", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
- Use username instead of name for avatar.
- Manage whether to recieve email for new followers.
- Change members to users.
- Show only yours and users you follow events.
- Remove addresses and phone numbers from users profile.
- Move graduated in.
